### PR TITLE
feat: enable setting merge method to pull request merges

### DIFF
--- a/pkg/commit/commit.go
+++ b/pkg/commit/commit.go
@@ -30,6 +30,7 @@ type CommitOptions struct {
 	RetryBackoff                time.Duration
 	PullRequestSourceBranchName string
 	PullRequestBody             string
+	MergeMethod                 string
 }
 
 func CreateCommit(ctx context.Context, client *github.Client, options *CommitOptions) error {
@@ -133,8 +134,12 @@ func CreateCommit(ctx context.Context, client *github.Client, options *CommitOpt
 		return err
 	}
 
+	prOpts := &github.PullRequestOptions{
+		MergeMethod: options.MergeMethod,
+	}
+
 	for retryCount := 1; retryCount <= options.MaxRetries; retryCount++ {
-		_, res, err := client.PullRequests.Merge(ctx, options.RepoOwner, options.RepoName, pr.GetNumber(), commit.GetMessage(), nil)
+		_, res, err := client.PullRequests.Merge(ctx, options.RepoOwner, options.RepoName, pr.GetNumber(), commit.GetMessage(), prOpts)
 		if err == nil {
 			// PR was merged, so we can attempt to remove our working branch.
 			// This isn't a critical operation, hence we do not error out if we fail to do so.


### PR DESCRIPTION
Should fix error when merging changes in https://github.com/form3tech-oss/terraform-provider-codeowners:

```
405 Merge commits are not allowed on this repository
```

Related to: https://github.com/terraform-aws-modules/meta/issues/2